### PR TITLE
fix: Downgrade slf4j

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    
+    ignore:
+        # Ignore slf4j-api major version bump because 1.x and 2.x are not compatible
+      - dependency-name: "slf4j-api"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <junit.version>5.9.2</junit.version>
         <fabric8-client.version>6.5.1</fabric8-client.version>
-        <slf4j.version>2.0.7</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.20.0</log4j.version>
         <mokito.version>5.2.0</mokito.version>
         <mokito.version>5.2.0</mokito.version>


### PR DESCRIPTION
As explained in #90, 2.x does not work with the log4j-slf4j-impl version.

Closes #90